### PR TITLE
Updates to the upcoming oneAPI Community Forum meetings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,10 +76,6 @@ Upcoming oneAPI Community Forum Meetings
    * - November 14th 2022, 5:30pm US Central Time
      - SC22 Meetup
      - Fairmont Dallas
-     - Contact_
-   * - November 23rd 2022, 10am US Central Time
-     - Math SIG
-     - Virtual
      - `RSVP Form`_
    * - December 14th 2022, 9am US Central Time
      - Annual Meeting


### PR DESCRIPTION
This removes the cancelled Math SIG meeting, while also fixing the "how to join" information for the SC22 Meetup.

Can view changes here: https://github.com/sknepper/oneAPI-tab/tree/oneMKL-Meeting-Update