### PR TITLE
Update Math SIG meeting times.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Upcoming oneAPI Community Forum Meetings
      - Hardware SIG
      - Virtual
      - Contact_
-   * - 8 March 2023, 11-12am US Central Time
+   * - 8 March 2023, 9-10am US Central Time
      - Math SIG
      - Virtual
      - Contact_


### PR DESCRIPTION
Pacific time is only 2 hours earlier than Central time.